### PR TITLE
Added insertion of entry template upon creation of new LA page

### DIFF
--- a/labarchivesIntegration/labarchivesCallObj.m
+++ b/labarchivesIntegration/labarchivesCallObj.m
@@ -429,6 +429,9 @@ classdef labarchivesCallObj
                     obj.notebook_name,obj.folder_name,obj.page_name);
                 obj = obj.insertNode(obj.uid,obj.nid,obj.fid,obj.page_name,false);
                 obj.pid = obj.response.tree_dash_tools.node.tree_dash_id.Text;
+                
+                %% insert entry template when page is created
+                obj.insertEntryTemplate;
             end        
             
             


### PR DESCRIPTION
When the labarchivesCallObj creates a new page it will automatically insert a new entry template into the new notebook page. This was previously being done in by the FileSystem class in the Mahou repo but was inserting an entry template every time a FileSystem object was initialized instead of only when the page was created.